### PR TITLE
Adds error toast

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@
     <NavBar />
     <router-view />
     <Footer />
+    <Notification :error="error" />
   </div>
 </template>
 
@@ -31,7 +32,28 @@
 <script>
 import NavBar from "@/layouts/NavBar";
 import Footer from "@/layouts/Footer";
+import Notification from "@/components/shared/Notification.vue";
+import { UserNotificationError } from "@/types/error";
+
 export default {
-  components: { NavBar, Footer },
+  components: { NavBar, Footer, Notification },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  data() {
+    return {
+      error: {},
+    };
+  },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  errorCaptured(err) {
+    // all user notification errors are handled here
+    if (err instanceof UserNotificationError) {
+      this.error = {
+        message: err.message,
+        data: err.errorData,
+        code: err.errorCode,
+      };
+    }
+    return false;
+  },
 };
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <NavBar />
     <router-view />
     <Footer />
-    <Notification :error="error" />
+    <Notification :error="error" :delay="5000" />
   </div>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,7 +33,7 @@
 import NavBar from "@/layouts/NavBar";
 import Footer from "@/layouts/Footer";
 import Notification from "@/components/shared/Notification.vue";
-import { UserNotificationError } from "@/types/error";
+import { ApiError, UserNotificationError } from "@/types/error";
 
 export default {
   components: { NavBar, Footer, Notification },
@@ -46,7 +46,7 @@ export default {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   errorCaptured(err) {
     // all user notification errors are handled here
-    if (err instanceof UserNotificationError) {
+    if (err instanceof UserNotificationError || err instanceof ApiError) {
       this.error = {
         message: err.message,
         data: err.errorData,

--- a/src/components/shared/Notification.vue
+++ b/src/components/shared/Notification.vue
@@ -1,9 +1,35 @@
 <template>
   <transition appear name="fade">
-    <div v-if="show" class="notification">
-      <div class="title">{{ error.message }} [code: {{ error.code }}]</div>
-      <div>
-        <p>{{ error.data }}</p>
+    <div
+      v-if="show"
+      aria-live="polite"
+      aria-atomic="true"
+      style="min-height: 200px"
+      class="toast-container position-fixed justify-content-center align-items-center col-md-4 notification"
+    >
+      <div
+        class="bg-danger box-header"
+        tarnclass="toast"
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+      >
+        <div class="toast-header">
+          <strong class="ml-0">
+            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+            {{ error.message }} [code: {{ error.code }}]
+          </strong>
+          <button
+            type="button"
+            class="mr-2 mb-1 ml-auto close"
+            data-dismiss="toast"
+            aria-label="Close"
+            @click="close()"
+          >
+            <span aria-hidden="true">&times;</span>
+        </button>
+        </div>
+        <div class="toast-body">{{ error.data }}</div>
       </div>
     </div>
   </transition>
@@ -17,6 +43,10 @@ export default {
       type: Object,
       required: true,
     },
+    delay: {
+      type: Number,
+      required: true,
+    },
   },
   data() {
     return {
@@ -28,27 +58,33 @@ export default {
     error() {
       this.show = true;
       clearTimeout(this.timeout);
+      const displayTime = this.delay;
       this.timeout = setTimeout(() => {
         this.show = false;
-      }, 3000);
+      }, displayTime);
+    },
+  },
+  methods: {
+    close() {
+      this.show = false;
     },
   },
 };
 </script>
 
 <style scoped>
-/* TODO: Adjust styles */
 
 .notification {
   position: fixed;
-  left: 25vw;
   top: 1vh;
-  background-color: rgba(255, 0, 0, 70%);
-  padding: 1rem;
   width: 50vw;
-  border-radius: 0.4rem;
-  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  left: 33.3vw;
 }
+
+.box-header {
+  border-radius: 0.4rem;
+}
+
 .fade-enter-active,
 .fade-leave-active {
   transition: top 3s ease;

--- a/src/components/shared/Notification.vue
+++ b/src/components/shared/Notification.vue
@@ -1,0 +1,60 @@
+<template>
+  <transition appear name="fade">
+    <div v-if="show" class="notification">
+      <div class="title">{{ error.message }} [code: {{ error.code }}]</div>
+      <div>
+        <p>{{ error.data }}</p>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script>
+export default {
+  name: "ErrorNotification",
+  props: {
+    error: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      show: false,
+      timeout: 0,
+    };
+  },
+  watch: {
+    error() {
+      this.show = true;
+      clearTimeout(this.timeout);
+      this.timeout = setTimeout(() => {
+        this.show = false;
+      }, 3000);
+    },
+  },
+};
+</script>
+
+<style scoped>
+/* TODO: Adjust styles */
+
+.notification {
+  position: fixed;
+  left: 25vw;
+  top: 1vh;
+  background-color: rgba(255, 0, 0, 70%);
+  padding: 1rem;
+  width: 50vw;
+  border-radius: 0.4rem;
+  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+}
+.fade-enter-active,
+.fade-leave-active {
+  transition: top 3s ease;
+}
+.fade-enter,
+.fade-leave-to {
+  top: -2000px;
+}
+</style>

--- a/src/components/swap/SwapBox.vue
+++ b/src/components/swap/SwapBox.vue
@@ -113,6 +113,7 @@ import { createNamespacedHelpers } from "vuex";
 
 import SelectTokenModal from "@/components/shared/select-token/SelectTokenModal.vue";
 import { getDefaultSwapFrom, getDefaultSwapTo } from "@/utils/token-binding";
+import { UserNotificationError, ApiError } from "@/types/error";
 
 const { mapState } = createNamespacedHelpers("session");
 
@@ -179,6 +180,11 @@ export default defineComponent({
     },
     assignMaxValueToSwapValue() {
       this.swapFrom.value = this.swapFrom.balance;
+      throw new UserNotificationError(
+        "Some message to display",
+        "23432",
+        "Additional data to be shown"
+      );
     },
     toggleshowMaxTooltip() {
       this.showMaxTooltip = !this.showMaxTooltip;

--- a/src/components/swap/SwapBox.vue
+++ b/src/components/swap/SwapBox.vue
@@ -113,7 +113,6 @@ import { createNamespacedHelpers } from "vuex";
 
 import SelectTokenModal from "@/components/shared/select-token/SelectTokenModal.vue";
 import { getDefaultSwapFrom, getDefaultSwapTo } from "@/utils/token-binding";
-import { UserNotificationError, ApiError } from "@/types/error";
 
 const { mapState } = createNamespacedHelpers("session");
 
@@ -180,11 +179,6 @@ export default defineComponent({
     },
     assignMaxValueToSwapValue() {
       this.swapFrom.value = this.swapFrom.balance;
-      throw new UserNotificationError(
-        "Some message to display",
-        "23432",
-        "Additional data to be shown"
-      );
     },
     toggleshowMaxTooltip() {
       this.showMaxTooltip = !this.showMaxTooltip;

--- a/src/layouts/Footer.vue
+++ b/src/layouts/Footer.vue
@@ -1,8 +1,8 @@
 <template>
   <v-footer padless color="white" class="footer-rsk d-flex justify-center">
-    <v-col cols="11" class="pb-0">
+    <v-col cols="12" class="pb-0">
       <v-row justify="center" align="start" class="mx-0 py-md-0 py-xl-6">
-        <v-col>
+        <v-col cols="5">
           <v-row class="footer-logo mx-0" align="end">
             <span class="pb-2">Built by</span>
             <v-col class="pl-0 pb-2">
@@ -18,7 +18,7 @@
           </v-row>
           <p>Copyright © 2021 IOV Labs All rights reserved</p>
         </v-col>
-        <v-col cols="7" class="pt-4">
+        <v-col cols="5" class="pt-4">
           <v-row justify="center" class="mx-0 footer-links">
             <a href="https://www.iovlabs.org/" target="_blank">
               About IOV Labs
@@ -29,7 +29,7 @@
             </a>
           </v-row>
         </v-col>
-        <v-col class="pt-1">
+        <v-col cols="2" class="pt-1">
           <v-row justify="end" class="mx-0 footer-icons">
             <a href="https://twitter.com/rsksmart" target="_blank">
               <v-icon>mdi-twitter</v-icon>

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,0 +1,29 @@
+class ApiError extends Error {
+  errorCode: unknown;
+  errorData: unknown;
+  constructor(
+    message: string | undefined,
+    errorCode: unknown,
+    errorData: unknown
+  ) {
+    super(message);
+    this.errorCode = errorCode;
+    this.errorData = errorData;
+  }
+}
+
+class UserNotificationError extends Error {
+  errorCode: string;
+  errorData: string;
+  constructor(
+    message: string | undefined,
+    errorCode: string,
+    errorData: string
+  ) {
+    super(message);
+    this.errorCode = errorCode;
+    this.errorData = errorData;
+  }
+}
+
+export { ApiError, UserNotificationError };


### PR DESCRIPTION
Adds the error toast attached to the errorCaptured hook.

The new component includes the following features:
- Typed error handling (Api, UserNotification)
- Generic Notification component (to be extended, if necessary)
The current version only displays a danger button, with danger style. The component can be extended in the future to include more notification types (adding customizable styles based on data type bound, for example).

Usage:

when catching an error in the app, trigger an error as follows:

```
      import { UserNotificationError, ApiError } from "@/types/error";

...

      throw new UserNotificationError(
        "Some message to display",
        "23432",
        "Additional data to be shown"
      );

```