### PR TITLE
[GBI-736] - Misleading error message when the user has no rBTC for gas fees

### DIFF
--- a/src/components/swap/SwapBox.vue
+++ b/src/components/swap/SwapBox.vue
@@ -436,7 +436,7 @@ export default defineComponent({
         this.SEND_NOTIFICATION({
           message: {
             message: "Error Message",
-            data: `User has no balance to swap.`,
+            data: `Transaction can't proceed because there is not enough rBTC balance for gas fees.`,
             type: "danger",
           },
         });


### PR DESCRIPTION
https://rsklabs.atlassian.net/browse/GBI-736

<img width="569" alt="image" src="https://user-images.githubusercontent.com/19415907/178843501-52b9c4a5-4ba2-4105-af03-ce7b99381953.png">
